### PR TITLE
Fix ValueError formatting

### DIFF
--- a/llm_tools_mcp.py
+++ b/llm_tools_mcp.py
@@ -36,7 +36,7 @@ def get_discriminator_value(v: dict) -> str:
                 return type_value
             else:
                 raise ValueError(
-                    f"Unknown server 'type'. Provided 'type': ${type_value}. Allowed types: ${allowed_types}"
+                    f"Unknown server 'type'. Provided 'type': {type_value}. Allowed types: {allowed_types}"
                 )
         else:
             raise ValueError(


### PR DESCRIPTION
## Summary
- fix server type check message formatting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6846b1db03548331b02af293f3440ded