### PR TITLE
Fix message in test script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -3,5 +3,5 @@
 set -uo pipefail  
 
 echo "--------------------------------"
-echo "Running mypy..."
+echo "Running tests..."
 uv run pytest


### PR DESCRIPTION
## Summary
- adjust `test.sh` text to reference the pytest command

## Testing
- `./test.sh` *(fails: failed to download dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6846b63fc9d083319c0ee98e1c6e73e6