### PR TITLE
Add remote fetch example to integration test

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -95,3 +95,12 @@ async def test_remote_fetch_mcp():
     assert "fetch" in tool_names, (
         f"Should have a fetching tool. Found tools: {tool_names}"
     )
+
+    result = await mcp_client.call_tool(
+        "fetch",
+        "fetch",
+        url="https://example.com",
+    )
+
+    assert result is not None, "Tool call should return a result"
+    assert "Example Domain" in str(result)


### PR DESCRIPTION
## Summary
- extend `test_remote_fetch_mcp` to actually fetch https://example.com
- verify returned result contains "Example Domain"

## Testing
- `pytest -k test_remote_fetch_mcp -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6846b64d497083319524f25ba101000d