### PR TITLE
fix bug for tools with arguments named `name` or `server_name`

### DIFF
--- a/src/llm_tools_mcp/mcp_client.py
+++ b/src/llm_tools_mcp/mcp_client.py
@@ -98,7 +98,7 @@ class McpClient:
             tools_for_server[server_name] = tools.tools
         return tools_for_server
 
-    async def call_tool(self, server_name: str, name: str, **kwargs):
+    async def call_tool(self, server_name: str, name: str, /, **kwargs):
         async with self._client_session(server_name) as session:
             if session is None:
                 return (


### PR DESCRIPTION
Reproducer:

### Input

`server_with_events.py`

```py
from mcp.server.fastmcp import FastMCP

mcp = FastMCP("MyApp")

@mcp.tool()
def say_hello(name: str) -> str:
    """A simple tool that says hello."""
    return f"Hello, {name}"


if __name__ == "__main__":
    mcp.run() 
```

`mcp-repro.json`

```
{
    "mcpServers": {
        "my-app": {
            "command": "uvx",
            "args": ["--with", "mcp", "python3", "server_with_events.py"]
        }
    }
}
```

One liner to run (in the same directory as `mcp-repro.json` and `server_with_events.py`:

```bash
uvx --with llm-echo==0.3a3 --with llm==0.26 --with 'git+https://github.com/VirtusLab/llm-tools-mcp.git@9d0206212a8e3e193380f8bf2e8f297191554ea6' llm -T 'MCP("mcp-repro.json")' -m echo '{ "tool_calls": [ { "name": "say_hello", "arguments": { "name": "value1" } } ] }'
```

### Output

Error:

```
Error: McpClient.call_tool() got multiple values for argument 'name'"
```

Detailed output:

```
{
  "prompt": "",
  "system": "",
  "attachments": [],
  "stream": true,
  "previous": []
}{
  "prompt": "",
  "system": "",
  "attachments": [],
  "stream": true,
  "previous": [
    {
      "prompt": "{ \"tool_calls\": [ { \"name\": \"say_hello\", \"arguments\": { \"name\": \"value1\" } } ] }"
    }
  ],
  "tool_results": [
    {
      "name": "say_hello",
      "output": "Error: McpClient.call_tool() got multiple values for argument 'name'",
      "tool_call_id": null
    }
  ]
}
```